### PR TITLE
Stop telemetry from emitting per-pear/per-track attribute keys

### DIFF
--- a/lib/pears/core/available_pears.ex
+++ b/lib/pears/core/available_pears.ex
@@ -13,7 +13,7 @@ defmodule Pears.Core.AvailablePears do
     end)
   end
 
-  @decorate trace("available_pears.add_pear", include: [:available_pears, :pear, :order])
+  @decorate trace("available_pears.add_pear", include: [:pear, :order])
   def add_pear(available_pears, pear) do
     order = next_pear_order(available_pears)
     pear = Pear.set_order(pear, order)

--- a/lib/pears/core/pear.ex
+++ b/lib/pears/core/pear.ex
@@ -1,6 +1,8 @@
 defmodule Pears.Core.Pear do
   alias Pears.TzHelpers
 
+  # Keep slack_id/slack_name/timezone_offset off of span attributes
+  @derive {O11y.SpanAttributes, only: [:id, :name, :order, :track]}
   defstruct id: nil,
             name: nil,
             track: nil,

--- a/lib/pears/core/team.ex
+++ b/lib/pears/core/team.ex
@@ -111,14 +111,7 @@ defmodule Pears.Core.Team do
 
   @decorate trace(
               "team.rename_track",
-              include: [
-                :team,
-                :track_name,
-                :new_track_name,
-                :track,
-                :updated_assigned_pears,
-                :updated_tracks
-              ]
+              include: [:team, :track_name, :new_track_name, :track]
             )
   def rename_track(team, track_name, new_track_name) do
     track = find_track(team, track_name)
@@ -146,16 +139,7 @@ defmodule Pears.Core.Team do
 
   @decorate trace(
               "team.add_pear_to_track",
-              include: [
-                :team,
-                :pear_name,
-                :track_name,
-                :pear,
-                :track,
-                :updated_tracks,
-                :updated_available_pears,
-                :updated_assigned_pears
-              ]
+              include: [:team, :pear_name, :track_name, :pear, :track]
             )
   def add_pear_to_track(team, pear_name, track_name) do
     track = find_track(team, track_name)
@@ -186,16 +170,7 @@ defmodule Pears.Core.Team do
 
   @decorate trace(
               "team.remove_pear_from_track",
-              include: [
-                :team,
-                :pear_name,
-                :track_name,
-                :track,
-                :pears,
-                :updated_tracks,
-                :updated_available_pears,
-                :updated_assigned_pears
-              ]
+              include: [:team, :pear_name, :track_name, :track]
             )
   def remove_pear_from_track(team, pear_name, track_name) do
     track = find_track(team, track_name)
@@ -217,10 +192,8 @@ defmodule Pears.Core.Team do
     }
   end
 
-  @decorate trace("team.choose_anchors", include: [:team, :updated_tracks])
+  @decorate trace("team.choose_anchors", include: [:team])
   def choose_anchors(team) do
-    O11y.set_attributes(tracks: team.tracks)
-
     updated_tracks =
       team.tracks
       |> Enum.map(fn {name, track} -> {name, Track.choose_anchor(track)} end)
@@ -231,7 +204,7 @@ defmodule Pears.Core.Team do
 
   @decorate trace(
               "team.toggle_anchor",
-              include: [:team, :pear_name, :track_name, :track, :updated_tracks]
+              include: [:team, :pear_name, :track_name, :track]
             )
   def toggle_anchor(team, pear_name, track_name) do
     track = find_track(team, track_name)

--- a/lib/pears/core/track.ex
+++ b/lib/pears/core/track.ex
@@ -1,6 +1,9 @@
 defmodule Pears.Core.Track do
   alias Pears.Core.Pear
 
+  # The pears map is keyed by pear name; spreading it onto spans creates an
+  # unbounded attribute key space (app.<pear name>.*) in Honeycomb.
+  @derive {O11y.SpanAttributes, only: [:id, :name, :locked, :anchor]}
   defstruct id: nil, name: nil, locked: false, pears: %{}, anchor: nil
 
   def new(fields) do

--- a/test/pears/core/span_attributes_test.exs
+++ b/test/pears/core/span_attributes_test.exs
@@ -1,0 +1,93 @@
+defmodule Pears.Core.SpanAttributesTest do
+  # async: false — O11y.TestHelper stops/starts the :opentelemetry app per test
+  use ExUnit.Case, async: false
+  use O11y.TestHelper
+
+  alias Pears.Core.AvailablePears
+  alias Pears.Core.Pear
+  alias Pears.Core.Team
+  alias Pears.Core.Track
+
+  # runtime.exs sets traces_exporter: :none in test, which overrides the pid
+  # exporter otel_pid_reporter configures — point it at the test pid and restart.
+  setup do
+    Application.put_env(:opentelemetry, :traces_exporter, {:otel_exporter_pid, self()})
+    Application.stop(:opentelemetry)
+    {:ok, _} = Application.ensure_all_started(:opentelemetry)
+    :ok
+  end
+
+  describe "struct attribute derivation" do
+    test "pears only expose stable scalar fields" do
+      pear =
+        Pear.new(
+          id: 1,
+          name: "Pear One",
+          order: 2,
+          track: "Track One",
+          slack_id: "UXXXXXXX",
+          slack_name: "pear-one",
+          timezone_offset: -28_800
+        )
+
+      keys = pear |> O11y.SpanAttributes.get() |> Enum.map(fn {key, _} -> to_string(key) end)
+
+      assert Enum.sort(keys) == ["id", "name", "order", "track"]
+    end
+
+    test "tracks do not expose their name-keyed pears map" do
+      track =
+        Track.new(id: 1, name: "Track One", pears: %{})
+        |> Track.add_pear(Pear.new(name: "Pear One"))
+
+      keys = track |> O11y.SpanAttributes.get() |> Enum.map(fn {key, _} -> to_string(key) end)
+
+      assert Enum.sort(keys) == ["anchor", "id", "locked", "name"]
+    end
+  end
+
+  describe "traced functions" do
+    test "adding an available pear does not emit attributes keyed by pear names" do
+      available_pears = %{"Pear One" => Pear.new(name: "Pear One", order: 1)}
+
+      AvailablePears.add_pear(available_pears, Pear.new(name: "Pear Two"))
+
+      span = assert_span("available_pears.add_pear")
+      refute_attribute_keys_contain(span, ["Pear One", "Pear Two"])
+    end
+
+    test "assigning a pear does not emit attributes keyed by pear or track names" do
+      team =
+        Team.new(name: "Team One")
+        |> Team.add_pear("Pear One")
+        |> Team.add_track("Track One")
+
+      Team.add_pear_to_track(team, "Pear One", "Track One")
+
+      span = assert_span("team.add_pear_to_track")
+      refute_attribute_keys_contain(span, ["Pear One", "Track One"])
+    end
+
+    test "choosing anchors does not emit attributes keyed by track names" do
+      team =
+        Team.new(name: "Team One")
+        |> Team.add_pear("Pear One")
+        |> Team.add_track("Track One")
+        |> Team.add_pear_to_track("Pear One", "Track One")
+
+      Team.choose_anchors(team)
+
+      span = assert_span("team.choose_anchors")
+      refute_attribute_keys_contain(span, ["Pear One", "Track One"])
+    end
+  end
+
+  defp refute_attribute_keys_contain(span, names) do
+    keys = span.attributes |> Map.keys() |> Enum.map(&to_string/1)
+
+    for key <- keys, name <- names do
+      refute String.contains?(key, name),
+             "expected no span attribute keyed by #{inspect(name)}, found #{inspect(key)}"
+    end
+  end
+end

--- a/test/pears/core/span_attributes_test.exs
+++ b/test/pears/core/span_attributes_test.exs
@@ -52,8 +52,7 @@ defmodule Pears.Core.SpanAttributesTest do
 
       AvailablePears.add_pear(available_pears, Pear.new(name: "Pear Two"))
 
-      span = assert_span("available_pears.add_pear")
-      refute_attribute_keys_contain(span, ["Pear One", "Pear Two"])
+      refute_span_attribute_keys_contain("available_pears.add_pear", ["Pear One", "Pear Two"])
     end
 
     test "assigning a pear does not emit attributes keyed by pear or track names" do
@@ -64,8 +63,7 @@ defmodule Pears.Core.SpanAttributesTest do
 
       Team.add_pear_to_track(team, "Pear One", "Track One")
 
-      span = assert_span("team.add_pear_to_track")
-      refute_attribute_keys_contain(span, ["Pear One", "Track One"])
+      refute_span_attribute_keys_contain("team.add_pear_to_track", ["Pear One", "Track One"])
     end
 
     test "choosing anchors does not emit attributes keyed by track names" do
@@ -77,13 +75,22 @@ defmodule Pears.Core.SpanAttributesTest do
 
       Team.choose_anchors(team)
 
-      span = assert_span("team.choose_anchors")
-      refute_attribute_keys_contain(span, ["Pear One", "Track One"])
+      refute_span_attribute_keys_contain("team.choose_anchors", ["Pear One", "Track One"])
     end
   end
 
-  defp refute_attribute_keys_contain(span, names) do
-    keys = span.attributes |> Map.keys() |> Enum.map(&to_string/1)
+  # Matches the raw span record via O11y.RecordDefinitions, which compiles
+  # against the installed otel headers — unlike O11y.Span.from_record/1, which
+  # hard-codes a record arity and breaks across opentelemetry versions.
+  defp refute_span_attribute_keys_contain(span_name, names) do
+    assert_receive {:span, span(name: ^span_name, attributes: attributes)}
+
+    keys =
+      attributes
+      |> Tuple.to_list()
+      |> List.last()
+      |> Map.keys()
+      |> Enum.map(&to_string/1)
 
     for key <- keys, name <- names do
       refute String.contains?(key, name),


### PR DESCRIPTION
## Problem
Pear and track collections are maps **keyed by user-entered names**, and o11y spreads bare maps directly under the `app.` attribute namespace. Every pear/track name became its own attribute namespace in Honeycomb (`app.Mike.id`, `app.Mike.track`, `app.Mike.slack_id`, …) — an unbounded key space that grows with every name ever seen. `Pear` also had no `@derive` restriction, so `slack_id`/`slack_name` shipped on spans.

Worst emitter: `AvailablePears.add_pear` included the whole map *inside a reduce*, re-emitting the growing map once per pear added.

## Fix
- `@derive {O11y.SpanAttributes, only: ...}` on `Pear` (id/name/order/track) and `Track` (id/name/locked/anchor — excludes the name-keyed `pears` map)
- Removed name-keyed maps from `include:` lists in `AvailablePears.add_pear`, `Team.rename_track`, `add_pear_to_track`, `remove_pear_from_track`, `choose_anchors`, `toggle_anchor`, and dropped `O11y.set_attributes(tracks: team.tracks)` in `choose_anchors`
- `Team` was already derived correctly; scalar includes (`:team_name`, `:pear`, `:track`, counts) are untouched

## Test plan
- [x] TDD: new `span_attributes_test.exs` failed first with the exact production symptom (`app.Pear One.id`), green after the fix — covers both struct derivation and decorator span output via o11y's pid exporter
- [x] 295 tests green; compile --warnings-as-errors, format, credo --strict all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)