### PR TITLE
Fix board crash when :new_drag_n_drop flag is enabled

### DIFF
--- a/lib/pears_web/live/pairing_board_live.html.heex
+++ b/lib/pears_web/live/pairing_board_live.html.heex
@@ -60,7 +60,7 @@
     <div phx-hook="Drag" id="drag">
       <div class="dropzone grid gap-3" id="Unassigned">
         <%= for pear <- list_pears(@team.available_pears) do %>
-          <div draggable="true" id={@pear.name} class="draggable p-4 bg-blue-700 text-white">
+          <div draggable="true" id={pear.name} class="draggable p-4 bg-blue-700 text-white">
             {pear.name}
           </div>
         <% end %>

--- a/test/pears_web/live/pairing_board_live_test.exs
+++ b/test/pears_web/live/pairing_board_live_test.exs
@@ -59,6 +59,23 @@ defmodule PearsWeb.TeamLiveTest do
     end
   end
 
+  describe "with the new drag and drop flag enabled" do
+    setup :register_and_log_in_team
+
+    setup %{team: team} do
+      FeatureFlags.enable(:new_drag_n_drop, for_actor: team)
+      :ok
+    end
+
+    test "renders the board when the team has available pears", %{conn: conn, team: team} do
+      {:ok, _} = Pears.Persistence.add_pear_to_team(team.name, "Pear One")
+
+      {:ok, page_live, disconnected_html} = live(conn, ~p"/teams")
+      assert disconnected_html =~ "Pear One"
+      assert render(page_live) =~ "Pear One"
+    end
+  end
+
   describe "when logged out" do
     test "when not logged in, redirects to login", %{conn: conn} do
       {:error, {:redirect, %{to: redirected_to}}} = live(conn, "/teams")


### PR DESCRIPTION
## Problem
Enabling the `:new_drag_n_drop` feature flag crashed the whole board with a `KeyError` on render for any team with available pears. The Unassigned dropzone comprehension in `pairing_board_live.html.heex` used `id={@pear.name}` — referencing a nonexistent assign — instead of the comprehension variable `pear`.

## Fix
Use the comprehension variable: `id={pear.name}`, matching the track-pears comprehension below it.

## Test plan
- Added a LiveView render test (in the existing `async: false` flag-test file) that enables `:new_drag_n_drop` for the team, adds an available pear, mounts the board, and asserts it renders. It failed with the `KeyError` before the fix.
- `mix format`, `mix credo --strict`, `mix compile --warnings-as-errors`, and full `mix test` (296 tests, 0 failures) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)