### PR TITLE
Fix two TeamSession state bugs: stale rehydration and reverting facilitator

### DIFF
--- a/lib/pears/boundary/team_session.ex
+++ b/lib/pears/boundary/team_session.ex
@@ -2,7 +2,6 @@ defmodule Pears.Boundary.TeamSession do
   use GenServer
   use OpenTelemetryDecorator
 
-  alias Pears.Boundary.TeamManager
   alias Pears.Core.Team
   alias Pears.Persistence
 
@@ -58,7 +57,7 @@ defmodule Pears.Boundary.TeamSession do
 
   @decorate trace("team_session.find_or_start_session", include: [:team_name])
   def find_or_start_session(team_name) do
-    with {:ok, team} <- maybe_fetch_team_from_db(team_name),
+    with {:ok, team} <- fetch_team_from_db(team_name),
          {:ok, team} <- get_or_start_session(team) do
       {:ok, team}
     end
@@ -125,14 +124,10 @@ defmodule Pears.Boundary.TeamSession do
     GenServer.call(via(team_name), :get_new_facilitator)
   end
 
-  @decorate trace("team_session.maybe_fetch_team_from_db", include: [:team_name, :error])
-  defp maybe_fetch_team_from_db(team_name) do
-    with {:error, :not_found} <- TeamManager.lookup_team_by_name(team_name),
-         {:ok, team_record} <- Persistence.get_team_by_name(team_name),
-         team <- map_to_team(team_record) do
-      {:ok, team}
-    else
-      {:ok, team} -> {:ok, team}
+  @decorate trace("team_session.fetch_team_from_db", include: [:team_name, :error])
+  defp fetch_team_from_db(team_name) do
+    case Persistence.get_team_by_name(team_name) do
+      {:ok, team_record} -> {:ok, map_to_team(team_record)}
       error -> error
     end
   end

--- a/lib/pears/boundary/team_session.ex
+++ b/lib/pears/boundary/team_session.ex
@@ -255,12 +255,9 @@ defmodule Pears.Boundary.TeamSession do
   end
 
   def handle_call(:get_new_facilitator, _from, state) do
-    facilitator =
-      state
-      |> State.new_session_facilitator()
-      |> State.session_facilitator()
+    new_state = State.new_session_facilitator(state)
 
-    {:reply, {:ok, facilitator}, state, @timeout}
+    {:reply, {:ok, State.session_facilitator(new_state)}, new_state, @timeout}
   end
 
   @decorate trace("team_session.timeout")

--- a/test/pears/boundary/team_session_test.exs
+++ b/test/pears/boundary/team_session_test.exs
@@ -62,6 +62,19 @@ defmodule Pears.Boundary.TeamSessionTest do
       |> assert_pear_in_track("pear3", "track two")
       |> assert_track_locked("track two")
     end
+
+    test "rehydrates the latest team from the database after the session ends", %{name: name} do
+      {:ok, _} = Pears.add_team(name)
+      {:ok, _} = Pears.add_pear(name, "Pear One")
+      {:ok, _} = Pears.add_track(name, "Track One")
+      {:ok, _} = Persistence.add_pear_to_track(name, "Pear One", "Track One")
+
+      TeamSession.end_session(name)
+
+      {:ok, team} = TeamSession.find_or_start_session(name)
+
+      assert_pear_in_track(team, "Pear One", "Track One")
+    end
   end
 
   def name(_) do

--- a/test/pears_test.exs
+++ b/test/pears_test.exs
@@ -415,14 +415,22 @@ defmodule PearsTest do
 
   test "can pick a new random facilitator", %{name: name} do
     Pears.add_team(name)
-    Pears.add_pear(name, "Pear One")
-    Pears.add_pear(name, "Pear Two")
+    Enum.each(1..10, fn n -> Pears.add_pear(name, "Pear #{n}") end)
 
-    {:ok, facilitator} = Pears.facilitator(name)
-    {:ok, new_facilitator} = Pears.new_facilitator(name)
+    {:ok, original_facilitator} = Pears.facilitator(name)
 
-    assert Enum.member?(["Pear One", "Pear Two"], facilitator.name)
-    assert Enum.member?(["Pear One", "Pear Two"], new_facilitator.name)
+    # Shuffle until the random pick differs from the original so we can tell
+    # whether the session actually kept the new facilitator
+    new_facilitator =
+      Enum.find_value(1..100, fn _ ->
+        {:ok, candidate} = Pears.new_facilitator(name)
+        if candidate.name != original_facilitator.name, do: candidate
+      end)
+
+    assert new_facilitator
+
+    {:ok, current_facilitator} = Pears.facilitator(name)
+    assert current_facilitator.name == new_facilitator.name
   end
 
   describe "hand off reminders" do


### PR DESCRIPTION
## Problem
Two state bugs in `Pears.Boundary.TeamSession`:

1. **Stale rehydration source.** `maybe_fetch_team_from_db` consulted `TeamManager.lookup_team_by_name` first — an in-memory copy captured at team creation and never updated. Any team created since boot rehydrated from that stale, empty copy after its 60-minute session timeout, rendering an empty board.
2. **Facilitator shuffle silently reverted.** `handle_call(:get_new_facilitator)` computed the shuffled facilitator for the reply but kept the original state, so the next `Pears.facilitator/1` call returned the previous pick.

## Fix
- Drop the `TeamManager` lookup branch and always load the team via `Persistence.get_team_by_name` (the source of truth). `TeamManager` itself is left in place; removing it entirely is a separate, larger change.
- Bind the updated state in `:get_new_facilitator` and reply with it, so the shuffle sticks.

## Test plan
- New test: a team created and modified, whose session then ends, rehydrates the full team from the DB rather than the stale empty copy (failed before the fix with an empty board).
- Strengthened the "can pick a new random facilitator" test: with 10 pears, shuffle until the pick differs from the original, then assert `Pears.facilitator/1` returns the new pick (the old membership-only assertion couldn't catch the revert).
- Full suite: 296 tests, 0 failures. `mix format`, `mix credo --strict`, and `mix compile --warnings-as-errors` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)