### PR TITLE
Disable email-dependent auth flows; remove stale ngrok origin

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -11,6 +11,12 @@ import Config
 # before starting your production server.
 config :pears, PearsWeb.Endpoint, cache_static_manifest: "priv/static/cache_manifest.json"
 
+# Email delivery is intentionally disabled in production until a real
+# provider is wired up: the mailer still uses Swoosh.Adapters.Local, and
+# with local storage disabled below, any Mailer.deliver call exits.
+# Registration auto-confirms teams and password reset is unavailable, so
+# nothing should attempt to send email.
+
 # Configures Swoosh API Client
 config :swoosh, api_client: Swoosh.ApiClient.Finch, finch_name: Pears.Finch
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -51,8 +51,7 @@ if config_env() == :prod do
     ],
     check_origin: [
       "https://app.pears.dev",
-      "https://pears-app.fly.dev",
-      "https://welcome-duck-remarkably.ngrok-free.app"
+      "https://pears-app.fly.dev"
     ],
     secret_key_base: secret_key_base
 

--- a/lib/pears/accounts.ex
+++ b/lib/pears/accounts.ex
@@ -99,6 +99,9 @@ defmodule Pears.Accounts do
   @doc """
   Registers a team.
 
+  Teams are auto-confirmed because confirmation emails are disabled
+  until a real email provider is wired up.
+
   ## Examples
 
       iex> register_team(%{field: value})
@@ -111,6 +114,7 @@ defmodule Pears.Accounts do
   def register_team(attrs) do
     %Team{}
     |> Team.registration_changeset(attrs)
+    |> Team.confirm_changeset()
     |> Repo.insert()
   end
 

--- a/lib/pears_web/live/team_forgot_password_live.ex
+++ b/lib/pears_web/live/team_forgot_password_live.ex
@@ -1,24 +1,17 @@
 defmodule PearsWeb.TeamForgotPasswordLive do
   use PearsWeb, :live_view
 
-  alias Pears.Accounts
-
   def render(assigns) do
     ~H"""
     <div class="mx-auto max-w-sm">
       <.header class="text-center">
-        Forgot your password?
-        <:subtitle>We'll send a password reset link to your inbox</:subtitle>
+        Password reset is currently unavailable
+        <:subtitle>
+          We can't send password reset emails right now. Please contact the
+          site administrator if you've lost access to your account.
+        </:subtitle>
       </.header>
 
-      <.simple_form for={@form} id="reset_password_form" phx-submit="send_email">
-        <.input field={@form[:email]} type="email" placeholder="Email" required />
-        <:actions>
-          <.button phx-disable-with="Sending..." class="w-full">
-            Send password reset instructions
-          </.button>
-        </:actions>
-      </.simple_form>
       <p class="text-center mt-4">
         <.link href={~p"/teams/register"}>Register</.link>
         | <.link href={~p"/teams/log_in"}>Log in</.link>
@@ -28,23 +21,6 @@ defmodule PearsWeb.TeamForgotPasswordLive do
   end
 
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, form: to_form(%{}, as: "team"))}
-  end
-
-  def handle_event("send_email", %{"team" => %{"email" => email}}, socket) do
-    if team = Accounts.get_team_by_email(email) do
-      Accounts.deliver_team_reset_password_instructions(
-        team,
-        &url(~p"/teams/reset_password/#{&1}")
-      )
-    end
-
-    info =
-      "If your email is in our system, you will receive instructions to reset your password shortly."
-
-    {:noreply,
-     socket
-     |> put_flash(:info, info)
-     |> redirect(to: ~p"/")}
+    {:ok, socket}
   end
 end

--- a/lib/pears_web/live/team_login_live.ex
+++ b/lib/pears_web/live/team_login_live.ex
@@ -40,9 +40,6 @@ defmodule PearsWeb.TeamLoginLive do
 
                 <:actions>
                   <.input field={@form[:remember_me]} type="checkbox" label="Remember me" />
-                  <%!-- <.link href={~p"/teams/reset_password"} class="text-sm font-semibold">
-                  Forgot your password?
-                </.link> --%>
                 </:actions>
                 <:actions>
                   <.button phx-disable-with="Logging in...">

--- a/lib/pears_web/live/team_registration_live.ex
+++ b/lib/pears_web/live/team_registration_live.ex
@@ -80,12 +80,6 @@ defmodule PearsWeb.TeamRegistrationLive do
   def handle_event("save", %{"team" => team_params}, socket) do
     case Accounts.register_team(team_params) do
       {:ok, team} ->
-        {:ok, _} =
-          Accounts.deliver_team_confirmation_instructions(
-            team,
-            &url(~p"/teams/confirm/#{&1}")
-          )
-
         changeset = Accounts.change_team_registration(team)
         {:noreply, socket |> assign(trigger_submit: true) |> assign_form(changeset)}
 

--- a/test/pears/accounts_test.exs
+++ b/test/pears/accounts_test.exs
@@ -142,9 +142,13 @@ defmodule Pears.AccountsTest do
       {:ok, team} = Accounts.register_team(valid_team_attributes(name: name, email: email))
       assert team.email == email
       assert is_binary(team.hashed_password)
-      assert is_nil(team.confirmed_at)
       assert is_nil(team.password)
       refute team.enabled
+    end
+
+    test "auto-confirms the team since confirmation emails are disabled" do
+      {:ok, team} = Accounts.register_team(valid_team_attributes())
+      assert team.confirmed_at
     end
   end
 
@@ -314,7 +318,7 @@ defmodule Pears.AccountsTest do
 
   describe "update_team_email/2" do
     setup do
-      team = team_fixture()
+      team = unconfirmed_team_fixture()
       email = unique_team_email()
 
       token =
@@ -483,7 +487,7 @@ defmodule Pears.AccountsTest do
 
   describe "deliver_team_confirmation_instructions/2" do
     setup do
-      %{team: team_fixture()}
+      %{team: unconfirmed_team_fixture()}
     end
 
     test "sends token through notification", %{team: team} do
@@ -502,7 +506,7 @@ defmodule Pears.AccountsTest do
 
   describe "confirm_team/1" do
     setup do
-      team = team_fixture()
+      team = unconfirmed_team_fixture()
 
       token =
         extract_team_token(fn url ->

--- a/test/pears_web/live/team_confirmation_instructions_live_test.exs
+++ b/test/pears_web/live/team_confirmation_instructions_live_test.exs
@@ -8,7 +8,7 @@ defmodule PearsWeb.TeamConfirmationInstructionsLiveTest do
   alias Pears.Repo
 
   setup do
-    %{team: team_fixture()}
+    %{team: unconfirmed_team_fixture()}
   end
 
   describe "Resend confirmation" do

--- a/test/pears_web/live/team_confirmation_live_test.exs
+++ b/test/pears_web/live/team_confirmation_live_test.exs
@@ -8,7 +8,7 @@ defmodule PearsWeb.TeamConfirmationLiveTest do
   alias Pears.Repo
 
   setup do
-    %{team: team_fixture()}
+    %{team: unconfirmed_team_fixture()}
   end
 
   describe "Confirm team" do

--- a/test/pears_web/live/team_forgot_password_live_test.exs
+++ b/test/pears_web/live/team_forgot_password_live_test.exs
@@ -4,14 +4,12 @@ defmodule PearsWeb.TeamForgotPasswordLiveTest do
   import Phoenix.LiveViewTest
   import Pears.AccountsFixtures
 
-  alias Pears.Accounts
-  alias Pears.Repo
-
   describe "Forgot password page" do
-    test "renders email page", %{conn: conn} do
+    test "renders an unavailable notice instead of the email form", %{conn: conn} do
       {:ok, lv, html} = live(conn, ~p"/teams/reset_password")
 
-      assert html =~ "Forgot your password?"
+      assert html =~ "Password reset is currently unavailable"
+      refute has_element?(lv, "#reset_password_form")
       assert has_element?(lv, ~s|a[href="#{~p"/teams/register"}"]|, "Register")
       assert has_element?(lv, ~s|a[href="#{~p"/teams/log_in"}"]|, "Log in")
     end
@@ -24,40 +22,6 @@ defmodule PearsWeb.TeamForgotPasswordLiveTest do
         |> follow_redirect(conn, ~p"/")
 
       assert {:ok, _conn} = result
-    end
-  end
-
-  describe "Reset link" do
-    setup do
-      %{team: team_fixture()}
-    end
-
-    test "sends a new reset password token", %{conn: conn, team: team} do
-      {:ok, lv, _html} = live(conn, ~p"/teams/reset_password")
-
-      {:ok, conn} =
-        lv
-        |> form("#reset_password_form", team: %{"email" => team.email})
-        |> render_submit()
-        |> follow_redirect(conn, "/")
-
-      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "If your email is in our system"
-
-      assert Repo.get_by!(Accounts.TeamToken, team_id: team.id).context ==
-               "reset_password"
-    end
-
-    test "does not send reset password token if email is invalid", %{conn: conn} do
-      {:ok, lv, _html} = live(conn, ~p"/teams/reset_password")
-
-      {:ok, conn} =
-        lv
-        |> form("#reset_password_form", team: %{"email" => "unknown@example.com"})
-        |> render_submit()
-        |> follow_redirect(conn, "/")
-
-      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "If your email is in our system"
-      assert Repo.all(Accounts.TeamToken) == []
     end
   end
 end

--- a/test/pears_web/live/team_login_live_test.exs
+++ b/test/pears_web/live/team_login_live_test.exs
@@ -10,7 +10,7 @@ defmodule PearsWeb.TeamLoginLiveTest do
 
       assert html =~ "Log in"
       assert html =~ "create your team"
-      # assert html =~ "Forgot your password?"
+      refute html =~ "Forgot your password?"
     end
 
     test "redirects if already logged in", %{conn: conn} do
@@ -66,21 +66,6 @@ defmodule PearsWeb.TeamLoginLiveTest do
         |> follow_redirect(conn, ~p"/teams/register")
 
       assert login_html =~ "Register"
-    end
-
-    @tag :skip
-    test "redirects to forgot password page when the Forgot Password button is clicked", %{
-      conn: conn
-    } do
-      {:ok, lv, _html} = live(conn, ~p"/teams/log_in")
-
-      {:ok, conn} =
-        lv
-        |> element("main a", "Forgot your password?")
-        |> render_click()
-        |> follow_redirect(conn, ~p"/teams/reset_password")
-
-      assert conn.resp_body =~ "Forgot your password?"
     end
   end
 end

--- a/test/pears_web/live/team_registration_live_test.exs
+++ b/test/pears_web/live/team_registration_live_test.exs
@@ -3,6 +3,9 @@ defmodule PearsWeb.TeamRegistrationLiveTest do
 
   import Phoenix.LiveViewTest
   import Pears.AccountsFixtures
+  import Swoosh.TestAssertions
+
+  alias Pears.Accounts
 
   describe "Registration page" do
     test "renders registration page", %{conn: conn} do
@@ -55,6 +58,18 @@ defmodule PearsWeb.TeamRegistrationLiveTest do
       # assert response =~ name
       assert response =~ "Settings"
       assert response =~ "Log out"
+    end
+
+    test "auto-confirms the team and does not send a confirmation email", %{conn: conn} do
+      {:ok, lv, _html} = live(conn, ~p"/teams/register")
+
+      name = unique_team_name()
+      attrs = valid_team_attributes(name: name) |> Map.delete(:email)
+      form = form(lv, "#registration_form", team: attrs)
+      render_submit(form)
+
+      assert Accounts.get_team_by_name(name).confirmed_at
+      assert_no_email_sent()
     end
 
     test "renders errors for duplicated name", %{conn: conn} do

--- a/test/support/fixtures/accounts_fixtures.ex
+++ b/test/support/fixtures/accounts_fixtures.ex
@@ -25,6 +25,15 @@ defmodule Pears.AccountsFixtures do
     team
   end
 
+  # Registration auto-confirms teams; the email confirmation flows still
+  # need a team without a confirmed_at to exercise their edge cases.
+  def unconfirmed_team_fixture(attrs \\ %{}) do
+    attrs
+    |> team_fixture()
+    |> Ecto.Changeset.change(confirmed_at: nil)
+    |> Pears.Repo.update!()
+  end
+
   def extract_team_token(fun) do
     {:ok, captured_email} = fun.(&"[TOKEN]#{&1}[TOKEN]")
     [_, token | _] = String.split(captured_email.text_body, "[TOKEN]")


### PR DESCRIPTION
## Problem

The mailer is unwired phx.new scaffold: prod uses `Swoosh.Adapters.Local` with `config :swoosh, local: false`, so any `Mailer.deliver` call exits `:noproc`. Registration created the team row and then crashed the LiveView trying to send the confirmation email; forgot-password crashed the same way. Login never required `confirmed_at`, so confirmation was pure ceremony. Separately, `check_origin` in prod trusted a reclaimable free-tier ngrok subdomain as a WebSocket origin.

## Fix

- Auto-confirm teams at registration (reuses `Team.confirm_changeset/1` inside `Accounts.register_team/1`) and stop sending the confirmation email
- Forgot-password page now shows a "Password reset is currently unavailable" notice instead of the email form; the route is kept so bookmarks don't 404, and the token-based reset LiveView/routes remain as harmless dead paths
- Removed the (already commented-out) "Forgot your password?" link from the login page
- Left the `Accounts.deliver_*` functions in place for when a real provider returns; noted at the prod mailer config site that email is intentionally disabled
- Removed the stale ngrok dev-tunnel origin from `check_origin` in `config/runtime.exs`

## Test plan

- New test: `register_team/1` auto-confirms the team
- New test: registration LiveView confirms the team and sends no email (`Swoosh.TestAssertions.assert_no_email_sent/0`)
- Forgot-password test now asserts the unavailable notice and the absence of the email form
- Login page test asserts the forgot-password link is absent
- Added `unconfirmed_team_fixture/1` so the confirmation-flow tests (kept as dead-path coverage) still exercise unconfirmed teams
- Full suite: 294 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)