### PR TITLE
Fix hand-off reminder snapshot date check so stale snapshots are skipped

### DIFF
--- a/lib/pears.ex
+++ b/lib/pears.ex
@@ -12,6 +12,7 @@ defmodule Pears do
   alias Pears.Core.Pear
   alias Pears.Core.Team
   alias Pears.Persistence
+  alias Pears.Persistence.SnapshotRecord
   alias Pears.Slack
 
   @topic inspect(__MODULE__)
@@ -472,7 +473,7 @@ defmodule Pears do
     with {:ok, team} <- TeamSession.find_or_start_session(team_record.name),
          true <- FeatureFlags.enabled?(:hand_off_reminders, for: team),
          {:ok, snapshot} <- Persistence.get_latest_snapshot(team.name),
-         true <- is_snapshot_from_today(snapshot),
+         true <- SnapshotRecord.from_today?(snapshot),
          matches <- Team.misaligned_tz_matches(team) do
       Enum.each(matches, fn pears ->
         if quittin_time_for_earliest_pair?(pears, utc_now) do
@@ -486,10 +487,6 @@ defmodule Pears do
     pears
     |> Team.earliest_pear_in_match()
     |> Pear.quittin_time?(utc_now)
-  end
-
-  defp is_snapshot_from_today(snapshot) do
-    snapshot.inserted_at >= Date.utc_today()
   end
 
   @decorate trace("pears.validate_pear_available", include: [:team, :pear_name])

--- a/lib/pears/persistence/snapshot_record.ex
+++ b/lib/pears/persistence/snapshot_record.ex
@@ -11,6 +11,10 @@ defmodule Pears.Persistence.SnapshotRecord do
     timestamps()
   end
 
+  def from_today?(snapshot, today \\ Date.utc_today()) do
+    Date.compare(NaiveDateTime.to_date(snapshot.inserted_at), today) == :eq
+  end
+
   @doc false
   def changeset(snapshot, attrs) do
     snapshot

--- a/test/pears/persistence/snapshot_record_test.exs
+++ b/test/pears/persistence/snapshot_record_test.exs
@@ -1,0 +1,30 @@
+defmodule Pears.Persistence.SnapshotRecordTest do
+  use ExUnit.Case, async: true
+
+  alias Pears.Persistence.SnapshotRecord
+
+  describe "from_today?" do
+    test "is true when the snapshot was inserted today" do
+      snapshot = %SnapshotRecord{inserted_at: ~N[2026-06-10 12:00:00]}
+
+      assert SnapshotRecord.from_today?(snapshot, ~D[2026-06-10])
+    end
+
+    test "is false when the snapshot was inserted on a previous day" do
+      snapshot = %SnapshotRecord{inserted_at: ~N[2026-06-09 23:59:59]}
+
+      refute SnapshotRecord.from_today?(snapshot, ~D[2026-06-10])
+    end
+
+    test "defaults to comparing against today's UTC date" do
+      today_snapshot = %SnapshotRecord{inserted_at: NaiveDateTime.utc_now()}
+
+      yesterday_snapshot = %SnapshotRecord{
+        inserted_at: NaiveDateTime.add(NaiveDateTime.utc_now(), -1, :day)
+      }
+
+      assert SnapshotRecord.from_today?(today_snapshot)
+      refute SnapshotRecord.from_today?(yesterday_snapshot)
+    end
+  end
+end

--- a/test/pears_test.exs
+++ b/test/pears_test.exs
@@ -572,6 +572,74 @@ defmodule PearsTest do
 
       assert {:ok, _} = Pears.send_hand_off_reminders()
     end
+
+    test "does not send reminders when the latest snapshot is from a previous day", %{name: name} do
+      test_pid = self()
+
+      MockSlackClient
+      |> stub(:retrieve_access_tokens, fn _code, _url ->
+        SlackFixtures.valid_token_response(%{"access_token" => "valid_token"})
+      end)
+      |> stub(:channels, fn _, _ -> SlackFixtures.channels_response() end)
+      |> stub(:users, fn _, "" ->
+        SlackFixtures.users_response([
+          %{id: "XXXXXXXXXX", name: "pearone", tz_offset: -28800},
+          %{id: "YYYYYYYYYY", name: "peartwo", tz_offset: -18000}
+        ])
+      end)
+      |> stub(:find_or_create_group_chat, fn ["XXXXXXXXXX", "YYYYYYYYYY"], "valid_token" ->
+        SlackFixtures.channel_response("ZZZZZZZZZZ", "idk what a dm channel name is")
+      end)
+
+      {:ok, _} = Pears.add_team(name)
+      {:ok, _} = Pears.add_pear(name, "Pear One")
+      {:ok, _} = Pears.add_pear(name, "Pear Two")
+      {:ok, _} = Pears.add_track(name, "Track One")
+      {:ok, _} = Pears.add_pear_to_track(name, "Pear One", "Track One")
+      {:ok, _} = Pears.add_pear_to_track(name, "Pear Two", "Track One")
+      {:ok, _} = Pears.record_pears(name)
+
+      {:ok, _} = Slack.onboard_team(name, "valid_code")
+      {:ok, details} = Slack.get_details(name)
+
+      params = %{"Pear One" => "XXXXXXXXXX", "Pear Two" => "YYYYYYYYYY"}
+      {:ok, _} = Slack.save_slack_names(details, name, params)
+
+      backdate_snapshots(name)
+
+      # The Slack module rescues exceptions raised while sending messages, so a
+      # zero-count Mox expectation can't catch an unwanted send. Record the call
+      # by messaging the test process instead.
+      MockSlackClient
+      |> stub(:send_message, fn _channel, _blocks, _token ->
+        send(test_pid, :hand_off_reminder_sent)
+        %{"ok" => true}
+      end)
+
+      {:ok, _} =
+        -28800
+        |> Pears.TzHelpers.five_pm_in_local_time()
+        |> Pears.TzHelpers.local_time_to_utc()
+        |> Pears.send_hand_off_reminders()
+
+      refute_received :hand_off_reminder_sent
+    end
+  end
+
+  defp backdate_snapshots(name) do
+    yesterday =
+      NaiveDateTime.utc_now()
+      |> NaiveDateTime.add(-1, :day)
+      |> NaiveDateTime.truncate(:second)
+
+    {:ok, %{snapshots: snapshots}} = Persistence.get_team_by_name(name)
+
+    Enum.each(snapshots, fn snapshot ->
+      {:ok, _} =
+        snapshot
+        |> Ecto.Changeset.change(inserted_at: yesterday)
+        |> Repo.update()
+    end)
   end
 
   def name(_) do


### PR DESCRIPTION
## Problem
`is_snapshot_from_today/1` compared a `NaiveDateTime` struct to a `Date` struct with `>=`. In Erlang term ordering that compares map size (9 keys vs 5), so it was always true. The "recorded today" gate was a no-op and hourly hand-off reminders fired on stale snapshots from any prior day.

## Fix
- Extracted the predicate into `Pears.Persistence.SnapshotRecord.from_today?/2`, comparing dates with `Date.compare/2` (with an injectable `today` for testability).
- `Pears.send_hand_off_reminder/2` now uses it; the misnamed `is_snapshot_from_today/1` private function is gone.
- Intended behavior change: reminders are now suppressed when there is no same-day snapshot.

## Test plan
- New unit tests for `SnapshotRecord.from_today?/2` (today vs. previous day, and the `Date.utc_today/0` default).
- New integration test: a team with a snapshot backdated to yesterday gets no reminder at quittin' time. This test fails on `main` (a reminder is sent) and passes with the fix. Note: it detects the send via a message to the test process rather than a zero-count Mox expectation, because `do_send_message/3` now rescues exceptions and would swallow Mox's unexpected-call error.
- `mix format`, `mix credo --strict`, `mix compile --warnings-as-errors`, and the full `mix test` suite (299 tests, 0 failures) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)